### PR TITLE
Protect API endpoints with JWT

### DIFF
--- a/Gym/settings.py
+++ b/Gym/settings.py
@@ -118,3 +118,17 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
 
 STATIC_URL = 'static/'
+
+from datetime import timedelta
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ),
+}
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'AUTH_HEADER_TYPES': ('Bearer',),
+}

--- a/Gym/settings.py
+++ b/Gym/settings.py
@@ -125,6 +125,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
 }
 
 SIMPLE_JWT = {


### PR DESCRIPTION
## What was done
- Protected API endpoints using IsAuthenticated by default

## How to test
- GET /api/users/ without token -> 401
- GET /api/users/ with Bearer access token -> 200

Closes #2